### PR TITLE
Accept `mode` and `language` as prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,12 @@ const GOOGLE_MAPS_APIKEY = '…';
     origin={origin}
     destination={destination}
     apikey={GOOGLE_MAPS_APIKEY}
+    language="es"
+    mode="walking"
   />
 </MapView>
 ```
+**NOTE:** Default value for `mode` is `driving`, and for `language` is `en`. You can find more details about travel modes [here](https://developers.google.com/maps/documentation/javascript/examples/directions-travel-modes).
 
 Once the directions in between both coordinates has been fetched, a `MapView.Polyline` between the two will be drawn. Since the result rendered on screen is a `MapView.Polyline` component, all [`MapView.Polyline` props](https://github.com/airbnb/react-native-maps/blob/master/docs/polyline.md#props) – except for `coordinates` – are also accepted:
 

--- a/src/MapViewDirections.js
+++ b/src/MapViewDirections.js
@@ -57,6 +57,8 @@ class MapViewDirections extends Component {
 			apikey,
 			onReady,
 			onError,
+			mode,
+			language
 		} = this.props;
 
 		if (origin.latitude && origin.longitude) {
@@ -67,7 +69,7 @@ class MapViewDirections extends Component {
 			destination = `${destination.latitude},${destination.longitude}`;
 		}
 
-		this.fetchRoute(origin, destination, apikey)
+		this.fetchRoute(origin, destination, apikey, mode, language)
 			.then(result => {
 				this.setState(result);
 				onReady && onReady(result);
@@ -79,9 +81,8 @@ class MapViewDirections extends Component {
 			});
 	}
 
-	fetchRoute = (origin, destination, apikey) => {
-		const mode = 'driving';
-		const url = `https://maps.googleapis.com/maps/api/directions/json?origin=${origin}&destination=${destination}&key=${apikey}&mode=${mode}`;
+	fetchRoute = (origin, destination, apikey, mode, language) => {
+		const url = `https://maps.googleapis.com/maps/api/directions/json?origin=${origin}&destination=${destination}&key=${apikey}&mode=${mode}&language=${language}`;
 
 		return fetch(url)
 			.then(response => response.json())
@@ -123,6 +124,8 @@ class MapViewDirections extends Component {
 			apikey, // eslint-disable-line no-unused-vars
 			onReady, // eslint-disable-line no-unused-vars
 			onError, // eslint-disable-line no-unused-vars
+			mode, // eslint-disable-line no-unused-vars
+			language, // eslint-disable-line no-unused-vars
 			...props
 		} = this.props;
 
@@ -151,6 +154,8 @@ MapViewDirections.propTypes = {
 	apikey: PropTypes.string.isRequired,
 	onReady: PropTypes.func,
 	onError: PropTypes.func,
+	mode: PropTypes.string,
+	language: PropTypes.string
 };
 
 export default MapViewDirections;


### PR DESCRIPTION
This resolves #6 and #7 

The `language` and `mode` props are optional. We don't have to provide extra controls for their values. Because, 

Default language is English. We are OK here. 

And default mode is `driving`. Options are `driving`, `walking`, `transport` and `bicycling`. 