### PR TITLE
Added onChangeRout event and url prop

### DIFF
--- a/src/MapViewDirections.js
+++ b/src/MapViewDirections.js
@@ -97,9 +97,20 @@ class MapViewDirections extends Component {
 			});
 	}
 
-	fetchRoute = (origin, waypoints, destination, apikey, mode, language) => {
-		const url = `https://maps.googleapis.com/maps/api/directions/json?origin=${origin}&waypoints=${waypoints}&destination=${destination}&key=${apikey}&mode=${mode}&language=${language}`;
+	//added to access to full json response; Only executed when the request is successful (http status 200)
+	onChangeRoute(retrievedDirections) {
+		//handled by parent component
+		this.props.onChangeRoute(retrievedDirections);
+	}
 
+	fetchRoute = (origin, waypoints, destination, apikey, mode, language) => {
+		//check if url prop is provided, if not, then use default Google's URL
+		let url = this.props.url || 'https://maps.googleapis.com/maps/api/directions/json';
+		//if using a URL (custom or default), then add default parameters to it
+		//if using a custom Request object then leave it as it is 
+		if (typeof (url) === 'string') {
+			url += `?origin=${origin}&waypoints=${waypoints}&destination=${destination}&key=${apikey}&mode=${mode}&language=${language}`;
+		}
 		return fetch(url)
 			.then(response => response.json())
 			.then(json => {
@@ -112,7 +123,8 @@ class MapViewDirections extends Component {
 				if (json.routes.length) {
 
 					const route = json.routes[0];
-
+					//execute event
+					this.onChangeRoute(json);
 					return Promise.resolve({
 						distance: route.legs.reduce((carry, curr) => {
 							return carry + curr.distance.value;


### PR DESCRIPTION
The onChangeRoute event provides the full json response from the server, also notifying whenever a route has changed. I needed to access other data like time and distance for the full route, so I did this.

Also Added URL prop, which can be a custom URL or a complete Request object, thus being able to completely customize the request. You can even leave it blank to use default Google's server. I needed to send the request to a middleware to have a better management of my app, also needed to use custom headers for authentication purposes.
Any doubt feel free to ask.
I hope this could help someone!