### PR TITLE
Log error on gmaps api request

### DIFF
--- a/src/MapViewDirections.js
+++ b/src/MapViewDirections.js
@@ -150,6 +150,12 @@ class MapViewDirections extends Component {
 				} else {
 					return Promise.reject();
 				}
+			})
+			.catch(err => {
+				console.warn(
+          'react-native-maps-directions Error on GMAPS route request',
+          err
+        );
 			});
 	}
 


### PR DESCRIPTION
I think this would be useful in many cases with the Gmaps API Key, I couldn't see that my Gmaps request limit exceeded until I log the error on the API fetch request