### PR TITLE
Added region prop to prevent incorrect route 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Once the directions in between `destination` and `origin` has been fetched, a `M
 | `mode` | `String` | `"driving"` | Which transportation mode to use when calculating directions. Allowed values are `"driving"`, `"bicycling"`, `"walking"`, and `"transit"`. _(See [here](https://developers.google.com/maps/documentation/javascript/examples/directions-travel-modes) for more info)_.
 | `resetOnChange` | `boolean` | `true` | Tweak if the rendered `MapView.Polyline` should reset or not when calculating the route between `origin` and `destionation`. Set to `false` if you see the directions line glitching.
 | `directionsServiceBaseUrl` | `string` | _(Google's)_ | Base URL of the Directions Service (API) you are using. By default the Google Directions API is used (`"https://maps.googleapis.com/maps/api/directions/json"`). Usually you won't need to change this.
+| `region` | `String` | | If you are using strings for **origin** or **destination**, sometimes you will get an incorrect route because Google Maps API needs the region where this places belong to. See [here](https://developers.google.com/maps/documentation/javascript/localization#Region) for more info.
 
 #### More props
 

--- a/src/MapViewDirections.js
+++ b/src/MapViewDirections.js
@@ -74,6 +74,7 @@ class MapViewDirections extends Component {
 			mode = 'driving',
 			language = 'en',
 			directionsServiceBaseUrl = 'https://maps.googleapis.com/maps/api/directions/json',
+			region,
 		} = props;
 
 		if (!origin || !destination) {
@@ -102,7 +103,7 @@ class MapViewDirections extends Component {
 			waypoints: waypoints ? waypoints.split('|') : [],
 		});
 
-		this.fetchRoute(directionsServiceBaseUrl, origin, waypoints, destination, apikey, mode, language)
+		this.fetchRoute(directionsServiceBaseUrl, origin, waypoints, destination, apikey, mode, language, region)
 			.then(result => {
 				if (!this._mounted) return;
 				this.setState(result);
@@ -115,12 +116,12 @@ class MapViewDirections extends Component {
 			});
 	}
 
-	fetchRoute(directionsServiceBaseUrl, origin, waypoints, destination, apikey, mode, language) {
+	fetchRoute(directionsServiceBaseUrl, origin, waypoints, destination, apikey, mode, language, region) {
 
 		// Define the URL to call. Only add default parameters to the URL if it's a string.
 		let url = directionsServiceBaseUrl;
 		if (typeof (directionsServiceBaseUrl) === 'string') {
-			url += `?origin=${origin}&waypoints=${waypoints}&destination=${destination}&key=${apikey}&mode=${mode}&language=${language}`;
+			url += `?origin=${origin}&waypoints=${waypoints}&destination=${destination}&key=${apikey}&mode=${mode}&language=${language}&region=${region}`;
 		}
 
 		return fetch(url)
@@ -167,6 +168,7 @@ class MapViewDirections extends Component {
 			onError, // eslint-disable-line no-unused-vars
 			mode, // eslint-disable-line no-unused-vars
 			language, // eslint-disable-line no-unused-vars
+			region,
 			...props
 		} = this.props;
 
@@ -209,6 +211,7 @@ MapViewDirections.propTypes = {
 	language: PropTypes.string,
 	resetOnChange: PropTypes.bool,
 	directionsServiceBaseUrl: PropTypes.string,
+	region: PropTypes.string,
 };
 
 export default MapViewDirections;


### PR DESCRIPTION
When using string in origin or destination, sometimes you will get an incorrect because Google Maps API needs the `region` of this places to know what place in particular you are referring to. Adding this `prop`, will give this context of your region to be more accurate. See [this page](https://developers.google.com/maps/documentation/javascript/localization#Region)  for more info.