### PR TITLE
Fixed mode setting - again.. (This is confusing)

### DIFF
--- a/src/MapViewDirections.js
+++ b/src/MapViewDirections.js
@@ -126,7 +126,7 @@ class MapViewDirections extends Component {
 		// Define the URL to call. Only add default parameters to the URL if it's a string.
 		let url = directionsServiceBaseUrl;
 		if (typeof (directionsServiceBaseUrl) === 'string') {
-			url += `?origin=${origin}&waypoints=${waypoints}&destination=${destination}&key=${apikey}&mode=${mode}&language=${language}&region=${region}`;
+			url += `?origin=${origin}&waypoints=${waypoints}&destination=${destination}&key=${apikey}&mode=${mode.toLowerCase()}&language=${language}&region=${region}`;
 		}
 
 		return fetch(url)


### PR DESCRIPTION
In regards to merge #68 the modes setting was not working. Strangely enough google does document usage of upper case however this seems to fail in all my testing until lowercase was used.

My suggestion is to avoid changing back the documentation for this package and confusing users with the lowercase and uppercase change and disagreement with the google documents and to simply add a lowercase conversion when the fetch request is made. If you feel you would like to do more testing or roll back #68 that should also work I assume.