### PR TITLE
change travel mode from lowercase to uppercase

### DIFF
--- a/src/MapViewDirections.js
+++ b/src/MapViewDirections.js
@@ -136,7 +136,7 @@ class MapViewDirections extends Component {
 		// Define the URL to call. Only add default parameters to the URL if it's a string.
 		let url = directionsServiceBaseUrl;
 		if (typeof (directionsServiceBaseUrl) === 'string') {
-			url += `?origin=${origin}&waypoints=${waypoints}&destination=${destination}&key=${apikey}&mode=${mode.toLowerCase()}&language=${language}&region=${region}&departure_time=now`;
+			url += `?origin=${origin}&waypoints=${waypoints}&destination=${destination}&key=${apikey}&mode=${mode}&language=${language}&region=${region}&departure_time=now`;
 		}
 
 		return fetch(url)


### PR DESCRIPTION
## Description:
This pr addresses #87 
### Problem:
In the file ```MapViewDirections.js``` on `line 139` the URL generated after specifying a travel mode of either `TRANSIT` or `BICYCLING` returns an error as shown below.

<img width="200" height="210" alt="Screenshot 2019-10-14 at 15 21 12" src="https://user-images.githubusercontent.com/12236213/66755444-a57b2580-eea0-11e9-8ae8-6b2ae82b22b2.png">

The URL generated (```https://maps.googleapis.com/maps/api/directions/json?origin=0.333278,32.5934604&waypoints=&destination=0.044721,32.443055&key=API_KEY&mode=bicycling&language=en&region=undefined&departure_time=now```) as seen the mode case is changed back again to lowercase
###Changes made:

change `&mode=${mode.toLowerCase()}` to `&mode=${mode}`
