### PR TITLE
onError will be now also called when there is a route request error.

### DIFF
--- a/src/MapViewDirections.js
+++ b/src/MapViewDirections.js
@@ -165,7 +165,7 @@ class MapViewDirections extends Component {
 			}
 
 			return (
-				this.fetchRoute(directionsServiceBaseUrl, origin, waypoints, destination, apikey, mode, language, region, precision)
+				this.fetchRoute(directionsServiceBaseUrl, origin, waypoints, destination, apikey, mode, language, region, precision, onError)
 					.then(result => {
 						return result;
 					})
@@ -208,7 +208,7 @@ class MapViewDirections extends Component {
 		});
 	}
 
-	fetchRoute(directionsServiceBaseUrl, origin, waypoints, destination, apikey, mode, language, region, precision) {
+	fetchRoute(directionsServiceBaseUrl, origin, waypoints, destination, apikey, mode, language, region, precision, onError) {
 
 		// Define the URL to call. Only add default parameters to the URL if it's a string.
 		let url = directionsServiceBaseUrl;
@@ -255,6 +255,7 @@ class MapViewDirections extends Component {
 			})
 			.catch(err => {
 				console.warn('react-native-maps-directions Error on GMAPS route request', err);  // eslint-disable-line no-console
+				onError && onError(err);
 			});
 	}
 


### PR DESCRIPTION
Hi @bramus,

Just made some small changes so that the `onError` prop is called when there is a route request error. This is useful when, for example, Google Maps API doesn't found a route between two places and returns a 200 response with `geocoder_status: ZERO_RESULTS`. Or when the API key is incorrect.

Now with the `onError` callback always called on every error we can act accordingly like informing the user.

Tell me what you think if you have any feedback. And in case everything is OK feel free to merge changes. 🙂