### PR TITLE
Return the order of waypoints, useful when using optimise waypoints

### DIFF
--- a/src/MapViewDirections.js
+++ b/src/MapViewDirections.js
@@ -196,7 +196,7 @@ class MapViewDirections extends Component {
 				distance: 0,
 				duration: 0,
 				fares: [],
-				waypointOrder: []
+				waypointOrder: [] 
 			});
 
 			// Plot it out and call the onReady callback

--- a/src/MapViewDirections.js
+++ b/src/MapViewDirections.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import MapView from 'react-native-maps';
 import isEqual from 'lodash.isequal';
 
-const WAYPOINT_LIMIT = 10;
+const WAYPOINT_LIMIT = 25;
 
 class MapViewDirections extends Component {
 
@@ -116,7 +116,7 @@ class MapViewDirections extends Component {
 			for (let i = 0; i < chunckedWaypoints.length; i++) {
 				routes.push({
 					waypoints: chunckedWaypoints[i],
-					origin: (i === 0) ? initialOrigin : chunckedWaypoints[i-1][chunckedWaypoints[i-1].length - 1],
+					origin: (i === 0) ? initialOrigin : chunckedWaypoints[i][0],
 					destination: (i === chunckedWaypoints.length - 1) ? initialDestination : chunckedWaypoints[i+1][0],
 				});
 			}
@@ -177,6 +177,7 @@ class MapViewDirections extends Component {
 			);
 		})).then(results => {
 			// Combine all Directions API Request results into one
+			var x = 0;
 			const result = results.reduce((acc, { distance, duration, coordinates, fare, waypointOrder }) => {
 				acc.coordinates = [
 					...acc.coordinates,
@@ -188,15 +189,21 @@ class MapViewDirections extends Component {
 					...acc.fares,
 					fare,
 				];
-				acc.waypointOrder = waypointOrder;
 
+				//array comes in starting at 0. Need offset so waypoint arrays don't overlap numbers
+				waypointOrder = waypointOrder.map(a => a+(x*WAYPOINT_LIMIT))
+				acc.waypointOrder = [
+					...acc.waypointOrder,
+					...waypointOrder,
+				];
+				x++;
 				return acc;
 			}, {
 				coordinates: [],
 				distance: 0,
 				duration: 0,
 				fares: [],
-				waypointOrder: [] 
+				waypointOrder: []
 			});
 
 			// Plot it out and call the onReady callback

--- a/src/MapViewDirections.js
+++ b/src/MapViewDirections.js
@@ -95,7 +95,7 @@ class MapViewDirections extends Component {
 		if (!initialOrigin || !initialDestination) {
 			return;
 		}
-		
+
 		// Routes array which we'll be filling.
 		// We'll perform a Directions API Request for reach route
 		const routes = [];
@@ -105,8 +105,8 @@ class MapViewDirections extends Component {
 		if (splitWaypoints && initialWaypoints && initialWaypoints.length > WAYPOINT_LIMIT) {
 			// Split up waypoints in chunks with chunksize WAYPOINT_LIMIT
 			const chunckedWaypoints = initialWaypoints.reduce((accumulator, waypoint, index) => {
-				const numChunk = Math.floor(index / WAYPOINT_LIMIT); 
-				accumulator[numChunk] = [].concat((accumulator[numChunk] || []), waypoint); 
+				const numChunk = Math.floor(index / WAYPOINT_LIMIT);
+				accumulator[numChunk] = [].concat((accumulator[numChunk] || []), waypoint);
 				return accumulator;
 			}, []);
 
@@ -121,7 +121,7 @@ class MapViewDirections extends Component {
 				});
 			}
 		}
-		
+
 		// No splitting of the waypoints is requested/needed.
 		// ~> Use one single route
 		else {
@@ -247,6 +247,7 @@ class MapViewDirections extends Component {
 								}, [])
 						),
 						fare: route.fare,
+						waypointOrder: route.waypoint_order
 					});
 
 				} else {

--- a/src/MapViewDirections.js
+++ b/src/MapViewDirections.js
@@ -177,7 +177,7 @@ class MapViewDirections extends Component {
 			);
 		})).then(results => {
 			// Combine all Directions API Request results into one
-			const result = results.reduce((acc, { distance, duration, coordinates, fare }) => {
+			const result = results.reduce((acc, { distance, duration, coordinates, fare, waypointOrder }) => {
 				acc.coordinates = [
 					...acc.coordinates,
 					...coordinates,
@@ -188,6 +188,7 @@ class MapViewDirections extends Component {
 					...acc.fares,
 					fare,
 				];
+				acc.waypointOrder = waypointOrder;
 
 				return acc;
 			}, {
@@ -195,6 +196,7 @@ class MapViewDirections extends Component {
 				distance: 0,
 				duration: 0,
 				fares: [],
+				waypointOrder: []
 			});
 
 			// Plot it out and call the onReady callback


### PR DESCRIPTION
Had to tweak again to match git latest rather than npm latest. 

When using optimise waypoints it's useful to have the updated waypoint order returned. 