### PR TITLE
adding wayPointOrder property to the onReady callback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Tip: Don't forget to tweak the `language` prop when using localized location nam
 | Event Name | Returns | Notes
 |---|---|---|
 | `onStart` | `{ origin, destination, waypoints: [] }` | Callback that is called when the routing has started.
-| `onReady` | `{ distance: Number, duration: Number, coordinates: [], fare: Object }` | Callback that is called when the routing has succesfully finished. Note: distance returned in kilometers and duration in minutes.
+| `onReady` | `{ distance: Number, duration: Number, coordinates: [], fare: Object, waypointOrder: [[]] }` | Callback that is called when the routing has succesfully finished. Note: distance returned in kilometers and duration in minutes.
 | `onError` | `errorMessage` | Callback that is called in case the routing has failed.
 
 ## Extended Example

--- a/src/MapViewDirections.js
+++ b/src/MapViewDirections.js
@@ -270,7 +270,7 @@ class MapViewDirections extends Component {
 								}, [])
 						),
 						fare: route.fare,
-						wayPointOrder: route.waypoint_order,
+						waypointOrder: route.waypoint_order,
 					});
 
 				} else {

--- a/src/MapViewDirections.js
+++ b/src/MapViewDirections.js
@@ -184,7 +184,7 @@ class MapViewDirections extends Component {
 			);
 		})).then(results => {
 			// Combine all Directions API Request results into one
-			const result = results.reduce((acc, { distance, duration, coordinates, fare }) => {
+			const result = results.reduce((acc, { distance, duration, coordinates, fare, waypointOrder }) => {
 				acc.coordinates = [
 					...acc.coordinates,
 					...coordinates,
@@ -195,6 +195,10 @@ class MapViewDirections extends Component {
 					...acc.fares,
 					fare,
 				];
+				acc.waypointOrder = [
+					...acc.waypointOrder,
+					waypointOrder,
+				];
 
 				return acc;
 			}, {
@@ -202,6 +206,7 @@ class MapViewDirections extends Component {
 				distance: 0,
 				duration: 0,
 				fares: [],
+				waypointOrder: [],
 			});
 
 			// Plot it out and call the onReady callback
@@ -265,6 +270,7 @@ class MapViewDirections extends Component {
 								}, [])
 						),
 						fare: route.fare,
+						wayPointOrder: route.waypoint_order,
 					});
 
 				} else {


### PR DESCRIPTION
This helps in keeping a reference to the original waypoints to do any client-side processing.
Note: Assuming WAYPOINT_LIMIT is currently a constant, for any request containing more than 10 waypoints this would split the waypoints array into a 2D array.
So I'm returning waypointOrder param as [  [...],[...]...] so that it serves as a better reference to the split 2D waypoints.
This is pretty much along the lines of PR #127 but returning a 2D array is more helpful instead of the user making any assumptions about WATPOINT_LIMIT.
This is a matter of great urgency for my project. Appreciate if we can merge and release this change ASAP.
Let me know if any changes are needed from end.