### PR TITLE
Fixes Error: Element type is invalid error

### DIFF
--- a/src/MapViewDirections.js
+++ b/src/MapViewDirections.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import MapView from 'react-native-maps';
+import { Polyline } from 'react-native-maps';
 import isEqual from 'lodash.isequal';
 
 const WAYPOINT_LIMIT = 10;
@@ -308,7 +308,7 @@ class MapViewDirections extends Component {
 		} = this.props;
 
 		return (
-			<MapView.Polyline coordinates={coordinates} {...props} />
+			<Polyline coordinates={coordinates} {...props} />
 		);
 	}
 


### PR DESCRIPTION
With latest react-native-maps 1.0.0, the use of Polyline is required. Otherwise you get: `ERROR  Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined.`