### PR TITLE
Add support for polyline borders

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -212,6 +212,19 @@ declare module "react-native-maps-directions" {
      */
     strokeColor?: string;
     /**
+     * @number
+     * The stroke border width to use for the path
+     * 0 indicates no border.
+     * Default: 0
+     */
+    strokeBorderWidth?: number;
+    /**
+    * @string
+    * The stroke border color to use for the path.
+    * Default: "#FFF"
+    */
+    strokeBorderColor?: string;
+    /**
      * @Array
      * The stroke colors to use for the path (iOS only).
      * Must be the same length as coordinates.

--- a/src/MapViewDirections.js
+++ b/src/MapViewDirections.js
@@ -309,13 +309,13 @@ class MapViewDirections extends Component {
 
 		const borderPolylineProps = {
 			...props,
-			strokeWidth: this.strokeBorderWidth + this.strokeWidth,
-			strokeColor: this.strokeBorderColor,
+			strokeWidth: props.strokeBorderWidth + props.strokeWidth,
+			strokeColor: props.strokeBorderColor,
 		};
 
 		return (
 			<>
-				{this.strokeBorderWidth > 0 &&
+				{props.strokeBorderWidth &&
 					<Polyline coordinates={coordinates} {...borderPolylineProps} />
 				}
 				<Polyline coordinates={coordinates} {...props} />

--- a/src/MapViewDirections.js
+++ b/src/MapViewDirections.js
@@ -92,6 +92,9 @@ class MapViewDirections extends Component {
 			precision = 'low',
 			timePrecision = 'none',
 			channel,
+			strokeWidth = 1,
+			strokeBorderWidth = 0,
+			strokeBorderColor = '#FFF',
 		} = props;
 
 		if (!apikey) {
@@ -308,7 +311,10 @@ class MapViewDirections extends Component {
 		} = this.props;
 
 		return (
-			<Polyline coordinates={coordinates} {...props} />
+			<>
+				{strokeBorderWidth > 0 && <Polyline coordinates={coordinates} {...[...props, { strokeWidth: strokeBorderWidth + strokeWidth, strokeColor: strokeBorderColor}]} />}
+				<Polyline coordinates={coordinates} {...props} />
+			</>
 		);
 	}
 

--- a/src/MapViewDirections.js
+++ b/src/MapViewDirections.js
@@ -92,9 +92,6 @@ class MapViewDirections extends Component {
 			precision = 'low',
 			timePrecision = 'none',
 			channel,
-			strokeWidth = 1,
-			strokeBorderWidth = 0,
-			strokeBorderColor = '#FFF',
 		} = props;
 
 		if (!apikey) {
@@ -310,9 +307,17 @@ class MapViewDirections extends Component {
 			...props
 		} = this.props;
 
+		const borderPolylineProps = {
+			...props,
+			strokeWidth: this.strokeBorderWidth + this.strokeWidth,
+			strokeColor: this.strokeBorderColor,
+		};
+
 		return (
 			<>
-				{strokeBorderWidth > 0 && <Polyline coordinates={coordinates} {...[...props, { strokeWidth: strokeBorderWidth + strokeWidth, strokeColor: strokeBorderColor}]} />}
+				{this.strokeBorderWidth > 0 &&
+					<Polyline coordinates={coordinates} {...borderPolylineProps} />
+				}
 				<Polyline coordinates={coordinates} {...props} />
 			</>
 		);
@@ -358,6 +363,9 @@ MapViewDirections.propTypes = {
 	precision: PropTypes.oneOf(['high', 'low']),
 	timePrecision: PropTypes.oneOf(['now', 'none']),
 	channel: PropTypes.string,
+	strokeWidth: PropTypes.number,
+	strokeBorderWidth: PropTypes.number,
+	strokeBorderColor: PropTypes.string,
 };
 
 export default MapViewDirections;


### PR DESCRIPTION
This effectively draws a second polyline to function as a "border" of the original polyline.