### PR TITLE
Add showAlternatives prop to display alternative routes on the map 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -276,6 +276,35 @@ declare module "react-native-maps-directions" {
      * Boolean to allow a polyline to be tappable and use the onPress function.
      */
     tappable?: boolean;
+    /**
+     * @boolean
+     * Boolean to allow alternative routes to be shown and selected on the map.
+     * Note, you should set alternativeStroke* props to style the alternative route
+     * so that it can be differentiated from the currently selected one.
+     * onReady will be invoked again with the currently selected route if the route changes
+     * 
+     */
+    showAlternatives?: boolean;
+    /**
+     * @number
+     * The stroke width to use for the path - the line displayed
+     * by polyline between two navigation points.
+     * Default: 1
+     */
+    alternativeStrokeWidth?: number;
+    /**
+     * @string
+     * The stroke color to use for the path.
+     * Default: "#000"
+     */
+    alternativeStrokeColor?: string;
+    /**
+     * @Array
+     * The stroke colors to use for the path (iOS only).
+     * Must be the same length as coordinates.
+     * Default: null
+     */
+    alternativeStrokeColors?: Array<string>;
   }
 
   export default class MapViewDirections extends React.Component<

--- a/index.d.ts
+++ b/index.d.ts
@@ -305,6 +305,17 @@ declare module "react-native-maps-directions" {
      * Default: null
      */
     alternativeStrokeColors?: Array<string>;
+    /**
+     * @number
+     * The index of the currently selected route. This can be used to control
+     * the selected route from outside the component.
+     */
+    selectedRouteIndex?: number;
+    /**
+     * Callback that is called when an alternative route is selected by the user.
+     * It receives the index of the selected route.
+     */
+    onSelectRoute?: (index: number) => void;
   }
 
   export default class MapViewDirections extends React.Component<


### PR DESCRIPTION
Fixes #198.  I added a showAlternatives prop which when enabled sets the [alternatives](https://developers.google.com/maps/documentation/directions/get-directions#alternatives) parameter to true and then renders the alternative routes returned in the result using the alternativeStroke* properties.   The onReady prop gets invoked with the main route and then it will get invoked again when an alternative route is selected.  Also added selectedRouteIndex and onRouteSelected props to allow parent components to persist the last selected route. 